### PR TITLE
Ping a otros sitios

### DIFF
--- a/script.ps1
+++ b/script.ps1
@@ -1,4 +1,4 @@
-﻿       $servers = @("10.57.401.196", "yahoo.com", "4.4.4.4")
+﻿       $servers = @("10.57.401.196", "yahoo.com", "bing.com")
        foreach ($server in $servers) {
            Test-Connection -ComputerName $server -Count 2
        }

--- a/script.ps1
+++ b/script.ps1
@@ -1,4 +1,4 @@
-﻿       $servers = @("10.57.401.196", "google.com", "4.4.4.4")
+﻿       $servers = @("10.57.401.196", "yahoo.com", "4.4.4.4")
        foreach ($server in $servers) {
            Test-Connection -ComputerName $server -Count 2
        }


### PR DESCRIPTION
En esta rama, se han modificado los sitios a los que se hace ping, reemplazando google.com por bing.com, yahoo.com, y 1.1.1.1. Estos cambios fueron hechos para realizar pruebas de conectividad con diferentes servidores.